### PR TITLE
Updating NuGet dependencies

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.csproj
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.csproj
@@ -8,14 +8,17 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
+++ b/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
@@ -16,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.6" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
+++ b/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
@@ -5,7 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>EntityFrameworkCore.Manipulation.Extensions.SigningKey.snk</AssemblyOriginatorKeyFile>
-    <Version>1.0.0-preview6</Version>
+    <Version>1.0.0-preview7</Version>
     <Company />
     <Authors>Sebastian Blomberg</Authors>
     <PackageProjectUrl>https://github.com/sebbe33/EntityFrameworkCore.Manipulation.Extensions</PackageProjectUrl>


### PR DESCRIPTION
Updating the NuGet dependencies throughout the project to the latest available versions, with the goal of enabling updating of the same packages within consuming projects.

This change would also ultimately facilitate the migration of the project to .NET 5.