### PR TITLE
Bugfix: ReferenceTypes which aren't Nullable<T> of value null should be DbNull

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/TestEntity.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/TestEntity.cs
@@ -14,6 +14,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
 
         public long LongTestValue { get; set; }
 
+        public string StringTestValue { get; set; }
+
         public DateTime DateTimeTestValue { get; set; }
 
 		public DateTime? NullableDateTimeTestValue { get; set; }

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/InsertIfNotExistTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/InsertIfNotExistTests.cs
@@ -39,8 +39,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         {
             var expectedEntitiesToBeInserted = new[]
             {
-                new TestEntity { Id = "1", IntTestValue = 111, BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 15451455587546 },
-                new TestEntity { Id = "3", IntTestValue = 333, BoolTestValue = false, DateTimeTestValue = new DateTime(15645325746541), LongTestValue = 7451524264 },
+                new TestEntity { Id = "1", IntTestValue = 111, StringTestValue = "a", BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 15451455587546 },
+                new TestEntity { Id = "3", IntTestValue = 333, StringTestValue = "a", BoolTestValue = false, DateTimeTestValue = new DateTime(15645325746541), LongTestValue = 7451524264 },
             };
 
 			using var context = await ContextFactory.GetDbContextAsync(provider);
@@ -64,15 +64,15 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         {
             var existingEntities = new[]
             {
-                new TestEntity { Id = "2", IntTestValue = 222 },
-                new TestEntity { Id = "4", IntTestValue = 444 },
-                new TestEntity { Id = "5", IntTestValue = 333 },
+                new TestEntity { Id = "2", IntTestValue = 222, StringTestValue = "a" },
+                new TestEntity { Id = "4", IntTestValue = 444, StringTestValue = "a" },
+                new TestEntity { Id = "5", IntTestValue = 333, StringTestValue = "a" },
             };
 
             var expectedEntitiesToBeInserted = new[]
             {
-                new TestEntity { Id = "1", IntTestValue = 111, BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 15451455587546 },
-                new TestEntity { Id = "3", IntTestValue = 333, BoolTestValue = false, DateTimeTestValue = new DateTime(15645325746541), LongTestValue = 7451524264 },
+                new TestEntity { Id = "1", IntTestValue = 111, StringTestValue = "a", BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 15451455587546 },
+                new TestEntity { Id = "3", IntTestValue = 333, StringTestValue = "a", BoolTestValue = false, DateTimeTestValue = new DateTime(15645325746541), LongTestValue = 7451524264 },
             };
 
             // First, add the entities which should exist before we perform our test.
@@ -90,6 +90,29 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
             // Then check that the actual DB contains the expected entities
             var actualEntities = await context.TestEntities.ToArrayAsync();
             actualEntities.Should().BeEquivalentTo(existingEntities.Concat(expectedEntitiesToBeInserted));
+        }
+
+        // SQL server specific
+        [TestMethod]
+        public async Task InsertIfNotExistAsync_ShouldInsertDbNull_WhenObjectValueIsNull()
+        {
+            var expectedEntitiesToBeInserted = new[]
+            {
+                new TestEntity { Id = "1", StringTestValue = null, IntTestValue = 111, BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 15451455587546 },
+            };
+
+            using var context = await ContextFactory.GetDbContextAsync(DbProvider.SqlServer);
+
+            // Validate that the DB doesn't have any entities
+            (await context.TestEntities.CountAsync()).Should().Be(0);
+
+            // Invoke the method and check that the result is the expected entities
+            var actualInsertedEntities = await context.InsertIfNotExistAsync(context.TestEntities, expectedEntitiesToBeInserted);
+            actualInsertedEntities.Should().BeEquivalentTo(expectedEntitiesToBeInserted);
+
+            // Then check that the actual DB contains the expected entities
+            var actualEntities = await context.TestEntities.ToArrayAsync();
+            actualEntities.Should().BeEquivalentTo(expectedEntitiesToBeInserted);
         }
     }
 }

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
@@ -68,13 +68,13 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
 
 						var parameter = new SqlParameter($"value{parameters.Count}", value);
 
+						if (value == null)
+						{
+							parameter = new SqlParameter(parameter.ParameterName, (object)DBNull.Value);
+						}
+
 						if (nullableUnderlyingType != default)
 						{
-							if (value == null)
-							{
-								parameter = new SqlParameter(parameter.ParameterName, (object)DBNull.Value);
-							}
-
 							type = nullableUnderlyingType;
 						}
 


### PR DESCRIPTION
In the latest updates you missed the case where an object can be null but not be Nullable (e.g. a string).
Submitting a fix for it + test which should detect it. Otherwise we're getting an exception

```
The parameterized query '(@value0 uniqueidentifier, ...' expects the parameter '@value12', which was not supplied.
```