### PR TITLE
Reverting switch to SqlParameter for inline tables back EF params

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
+++ b/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
@@ -5,7 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>EntityFrameworkCore.Manipulation.Extensions.SigningKey.snk</AssemblyOriginatorKeyFile>
-    <Version>1.0.0-preview9.1.2</Version>
+    <Version>1.0.0-preview9.1.3</Version>
     <Company />
     <Authors>Sebastian Blomberg</Authors>
     <PackageProjectUrl>https://github.com/sebbe33/EntityFrameworkCore.Manipulation.Extensions</PackageProjectUrl>

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
@@ -36,12 +36,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
         }
 
         public static StringBuilder AppendValues<TEntity>(
-			this StringBuilder stringBuilder,
-			IProperty[] properties,
-			IEnumerable<TEntity> entities,
-			IList<object> parameters,
-			bool wrapInParanthesis = false,
-			bool useParameterPlaceholders = false)
+            this StringBuilder stringBuilder,
+            IProperty[] properties,
+            IEnumerable<TEntity> entities,
+            IList<object> parameters,
+            bool wrapInParanthesis = false)
             where TEntity : class
         {
             stringBuilder.Append(wrapInParanthesis ? " (" : " ");
@@ -52,44 +51,12 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
             foreach (TEntity entity in entities)
             {
                 stringBuilder.Append(" (");
-				foreach (IProperty property in properties)
-				{
-					if (useParameterPlaceholders)
-					{
-						// for each column value, create a placeholder, e.g. "{3}" used for the parameter
-						stringBuilder.Append("{").Append(parameters.Count).Append("},");
-						parameters.Add(property.PropertyInfo.GetValue(entity));
-					}
-					else
-					{
-						object value = property.PropertyInfo.GetValue(entity);
-						Type type = property.PropertyInfo.PropertyType;
-						var nullableUnderlyingType = Nullable.GetUnderlyingType(type);
-
-						var parameter = new SqlParameter($"value{parameters.Count}", value);
-
-						if (value == null)
-						{
-							parameter = new SqlParameter(parameter.ParameterName, (object)DBNull.Value);
-						}
-
-						if (nullableUnderlyingType != default)
-						{
-							type = nullableUnderlyingType;
-						}
-
-						if (type.Equals(typeof(DateTime)))
-						{
-							parameter.SqlDbType = SqlDbType.DateTime2;
-						}
-
-						// for each column value, create a paramet placeholder, e.g. "@value_5" used for the parameter
-						stringBuilder.Append("@").Append(parameter.ParameterName).Append(",");
-
-						// then add the actual value to the list of parameters
-						parameters.Add(parameter);
-					}
-				}
+                foreach (IProperty property in properties)
+                {
+                    // for each column value, create a placeholder, e.g. "{3}" used for the parameter
+                    stringBuilder.Append("{").Append(parameters.Count).Append("},");
+                    parameters.Add(property.PropertyInfo.GetValue(entity));
+                }
 
                 stringBuilder.Length--; // remove the last ","
                 stringBuilder.Append("),");
@@ -113,7 +80,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
                 return stringBuilder
                 .Append("SELECT * FROM (SELECT ")
                 .AppendJoin(", ", Enumerable.Range(1, properties.Length).Select(columnNumber => $"[column{columnNumber}] {properties[columnNumber - 1].GetColumnName()}"))
-                .Append(" FROM").AppendValues(properties, entities, parameters, wrapInParanthesis: true, useParameterPlaceholders: true)
+                .Append(" FROM").AppendValues(properties, entities, parameters, wrapInParanthesis: true)
                 .Append(") AS ").Append(tableAlias).Append(" ");
             }
 

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
@@ -40,10 +40,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
             IProperty[] properties,
             IEnumerable<TEntity> entities,
             IList<object> parameters,
-            bool wrapInParanthesis = false)
+            bool wrapInParenthesis = false)
             where TEntity : class
         {
-            stringBuilder.Append(wrapInParanthesis ? " (" : " ");
+            stringBuilder.Append(wrapInParenthesis ? " (" : " ");
 
             stringBuilder.Append("VALUES");
 
@@ -51,19 +51,21 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
             foreach (TEntity entity in entities)
             {
                 stringBuilder.Append(" (");
-                foreach (IProperty property in properties)
-                {
-                    // for each column value, create a placeholder, e.g. "{3}" used for the parameter
-                    stringBuilder.Append("{").Append(parameters.Count).Append("},");
-                    parameters.Add(property.PropertyInfo.GetValue(entity));
-                }
+				foreach (IProperty property in properties)
+				{
+					// for each column value, create a placeholder, e.g. "{3}" used for the parameter
+					stringBuilder.Append("{").Append(parameters.Count).Append("},");
 
-                stringBuilder.Length--; // remove the last ","
+					// then add the actual value to the list of parameters
+					parameters.Add(property.PropertyInfo.GetValue(entity));
+				}
+
+				stringBuilder.Length--; // remove the last ","
                 stringBuilder.Append("),");
             }
 
             stringBuilder.Length--; // remove the last ","
-            return stringBuilder.Append(wrapInParanthesis ? ") " : " ");
+            return stringBuilder.Append(wrapInParenthesis ? ") " : " ");
         }
 
         public static StringBuilder AppendSelectFromInlineTable<TEntity>(
@@ -80,12 +82,12 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
                 return stringBuilder
                 .Append("SELECT * FROM (SELECT ")
                 .AppendJoin(", ", Enumerable.Range(1, properties.Length).Select(columnNumber => $"[column{columnNumber}] {properties[columnNumber - 1].GetColumnName()}"))
-                .Append(" FROM").AppendValues(properties, entities, parameters, wrapInParanthesis: true)
+                .Append(" FROM").AppendValues(properties, entities, parameters, wrapInParenthesis: true)
                 .Append(") AS ").Append(tableAlias).Append(" ");
             }
 
             return stringBuilder
-                .Append("SELECT * FROM ").AppendValues(properties, entities, parameters, wrapInParanthesis: true)
+                .Append("SELECT * FROM ").AppendValues(properties, entities, parameters, wrapInParenthesis: true)
                 .Append(" AS ").Append(tableAlias).AppendColumnNames(properties, wrapInParanthesis: true);
         }
 


### PR DESCRIPTION
This is a potential fix for a perf degradation issue that occurred when switching to `SqlParameter` instead of using the EF-generated params. The issue was that in EF 3, queries couldn't get translated otherwise