### PR TITLE
Simple statement sync

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/ContextFactory.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/ContextFactory.cs
@@ -88,6 +88,14 @@ namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
                 context.ManipulationExtensionsConfiguration.SqlServerConfiguration.EntityTypesWithTriggers.Add(nameof(TestEntity));
                 context.ManipulationExtensionsConfiguration.SqlServerConfiguration.EntityTypesWithTriggers.Add(nameof(TestEntityCompositeKey));
             }
+            else if (testConfiguration == TestConfiguration.SqlServerMergeSync)
+            {
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.UseMerge = true;
+            }
+            else if (testConfiguration == TestConfiguration.SqlServerSimpleStatementsSync)
+            {
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.UseMerge = false;
+            }
 
             return context;
         }

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/TestConfiguration.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/TestConfiguration.cs
@@ -7,5 +7,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
         SqlServerRegularTableTypes,
         SqlServerMemoryOptimizedTableTypes,
         SqlServerOutputInto,
+        SqlServerMergeSync,
+        SqlServerSimpleStatementsSync
     }
 }

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
@@ -21,6 +21,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -48,6 +50,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -83,6 +87,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldUpdateAndReturnEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -116,6 +122,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -151,6 +159,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         [Ignore("Need to fix this case")]
         public async Task SyncAsync_ShouldDeleteAndReturnEntireSource_WhenSourceIsEmpty(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -178,6 +188,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndUpdateAndReturnEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -209,6 +221,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -242,6 +256,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -274,6 +290,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -308,6 +326,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -342,6 +362,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -378,6 +400,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndDeleteAndReturnMatchingTargetEntities_WhenTargetIsEntireTablee(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -414,6 +438,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndDeleteAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -452,6 +478,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -478,6 +506,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -511,6 +541,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -549,6 +581,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -589,6 +623,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -615,6 +651,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -647,6 +685,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldUpdateAndReturnEntities_WhenAllEntitiesMatchInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -683,6 +723,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -721,6 +763,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateIncludedPropertiesAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -783,6 +827,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateNonExcludedPropertiesAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact

--- a/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerManipulationExtensionsConfiguration.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerManipulationExtensionsConfiguration.cs
@@ -77,6 +77,6 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
         /// especially in regards to IO. It may also decrease performance in certain cases. This setting allows the consumer of the
         /// library to test which use cases is best for their specific scenario.
         /// </summary>
-        public bool UseMerge { get; set; }
+        public bool UseMerge { get; set; } = true;
     }
 }

--- a/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerManipulationExtensionsConfiguration.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerManipulationExtensionsConfiguration.cs
@@ -3,7 +3,6 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
-    using System.Globalization;
 
     /// <summary>
     /// Configuration for the EntityFrameworkCore.Manipulation.Extensions library.
@@ -63,5 +62,13 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
         /// <returns><c>true</c> if there was already an interceptor registered for <typeparamref name="TEntity"/>, <c>false</c> otherwise.</returns>
         public bool AddTableValuedParameterInterceptor<TEntity>(ITableValuedParameterInterceptor interceptor) =>
             this.TvpInterceptors.TryAdd(typeof(TEntity), interceptor ?? throw new ArgumentNullException(nameof(interceptor)));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to utilize SQL Server's MERGE statement for upserts and syncs, or whether to
+        /// used individual INSERT, UPDATE, and DELETE statements. The merge statement may increase performance for upserts and syncs,
+        /// especially in regards to IO. It may also decrease performance in certain cases. This setting allows the consumer of the
+        /// library to test which use cases is best for their specific scenario.
+        /// </summary>
+        public bool UseMerge { get; set; }
     }
 }

--- a/EntityFrameworkCore.Manipulation.Extensions/DeleteExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/DeleteExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace EntityFrameworkCore.Manipulation.Extensions
+namespace EntityFrameworkCore.Manipulation.Extensions
 {
     using EntityFrameworkCore.Manipulation.Extensions.Internal;
     using EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions;
@@ -59,6 +59,7 @@
             else
             {
                 stringBuilder
+                    .AppendLine("SET NOCOUNT ON;")
                     .AppendLine("WITH DeleteTarget AS (").Append(targetCommand).AppendLine(")")
                     .AppendLine("DELETE FROM DeleteTarget ")
                     .AppendLine("OUTPUT DELETED.* ");

--- a/EntityFrameworkCore.Manipulation.Extensions/InsertIfNotExistExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/InsertIfNotExistExtensions.cs
@@ -83,12 +83,15 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                     stringBuilder.AppendOutputDeclaration(userDefinedTableTypeName);
                 }
 
-                stringBuilder.AppendLine("INSERT INTO ").Append(tableName).AppendColumnNames(properties, wrapInParanthesis: true)
-                             .AppendOutputClauseLine(properties,  outputInto);
+                stringBuilder
+                    .AppendLine("SET NOCOUNT ON;")
+                    .AppendLine("INSERT INTO ").Append(tableName).AppendColumnNames(properties, wrapInParanthesis: true)
+                    .AppendOutputClauseLine(properties, outputInto, identifierPrefix: "inserted");
 
                 if (configuration.SqlServerConfiguration.ShouldUseTableValuedParameters(properties, entities))
                 {
-                    stringBuilder.Append("SELECT * FROM ")
+                    stringBuilder.Append("SELECT ").AppendColumnNames(properties, wrapInParanthesis: false)
+                        .Append(" FROM ")
                         .AppendTableValuedParameter(userDefinedTableTypeName, properties, entities, parameters)
                         .AppendLine(" AS source");
                 }

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/DatabaseFacadeExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/DatabaseFacadeExtensions.cs
@@ -16,7 +16,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
 
     public static class DatabaseFacadeExtensions
     {
-        private const string TableTypeGeneratorVersion = "1"; // This should be rev'd when the creation code for table types has changed
+        private const string TableTypeGeneratorVersion = "2"; // This should be rev'd when the creation code for table types has changed
 
         private static readonly ConcurrentDictionary<(string DatabaseName, string EntityTableName, string Configuration), string> UserDefinedTableTypeCache
             = new ConcurrentDictionary<(string, string, string), string>();
@@ -85,7 +85,9 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
                 schemaBuilder.Append(property.ColumnName).Append(' ').Append(property.ColumnType).Append(',');
             }
 
-            schemaBuilder.Length--; // remove the last ","
+            // We always append __Action for use as output variable when performing syncs. This field is very small, and as such it's a low cost to pay
+            // instead of creating a similar with just the addition of the action field.
+            schemaBuilder.Append("__Action CHAR(6)");
 
             string schema = schemaBuilder.ToString();
             string schemaHash = schema.GetDeterministicStringHash();

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
@@ -13,8 +13,6 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
 
     internal static class SqlCommandBuilderExtensions
     {
-        
-
         public static StringBuilder AppendColumnNames(
             this StringBuilder stringBuilder,
             IReadOnlyCollection<IProperty> properties,
@@ -117,7 +115,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
             string userDefinedTableTypeName,
             IProperty[] properties,
             IEnumerable<TEntity> entities,
-            IList<object> parameters)
+            IList<object> parameters,
+            bool includeActionColumn = false)
         {
             var dataTable = new DataTable();
 
@@ -134,6 +133,12 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
                 }
 
                 dataTable.Columns.Add(property.GetColumnName(), columnType);
+            }
+
+            if (includeActionColumn)
+            {
+                // Add the action column, which is part of every TVP type
+                dataTable.Columns.Add(DatabaseFacadeExtensions.TempOutputTableActionColumn, typeof(string));
             }
 
             // Add the entities as rows
@@ -168,7 +173,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
             this StringBuilder stringBuilder,
             IReadOnlyCollection<IProperty> properties,
             bool outputIntoTempTable,
-            bool includeAction = false)
+            bool includeAction = false,
+            string identifierPrefix = "deleted")
         {
             stringBuilder.Append("OUTPUT ");
 
@@ -177,7 +183,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
                 stringBuilder.Append("$action AS ").Append(DatabaseFacadeExtensions.TempOutputTableActionColumn).Append(", ");
             }
 
-            stringBuilder.AppendColumnNames(properties, false, identifierPrefix: "deleted");
+            stringBuilder.AppendColumnNames(properties, false, identifierPrefix);
 
             if (outputIntoTempTable)
             {

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
@@ -109,6 +109,12 @@
             string userDefinedTableTypeName,
             IProperty[] properties,
             IEnumerable<TEntity> entities,
+            IList<object> parameters) => stringBuilder.Append(CreateTableValuedParameter(userDefinedTableTypeName, properties, entities, parameters));
+
+        public static string CreateTableValuedParameter<TEntity>(
+            string userDefinedTableTypeName,
+            IProperty[] properties,
+            IEnumerable<TEntity> entities,
             IList<object> parameters)
         {
             var dataTable = new DataTable();
@@ -150,9 +156,7 @@
             };
             parameters.Add(parameter);
 
-            return stringBuilder.Append(parameter.ParameterName);
+            return parameter.ParameterName;
         }
-
-
     }
 }

--- a/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
@@ -159,9 +159,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                 string inlineTableAlias = joinAliasRegex.Match(fromJoinCommand).Value.Trim();
 
                 stringBuilder
+                    .AppendLine("SET NOCOUNT ON;")
                     .Append("UPDATE ").Append(tableName).AppendLine(" SET")
                         .AppendJoin(",", propertiesToUpdate.Select(property => FormattableString.Invariant($"{property.Name}={inlineTableAlias}.{property.Name}"))).AppendLine()
-                    .AppendOutputClauseLine(properties, outputInto)
+                    .AppendOutputClauseLine(properties, outputInto, identifierPrefix: "inserted")
                     .Append(fromJoinCommand)
                     .AppendLine(";");
 


### PR DESCRIPTION
Introduces an alternative to using `MERGE` for syncs for SQL Server, by composing a transaction of simple statements ( `INSERT`, `DELETE`, `UPDATE`)