### PR TITLE
Entity-specific configurations

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/ContextFactory.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/ContextFactory.cs
@@ -1,5 +1,6 @@
 namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
 {
+    using EntityFrameworkCore.Manipulation.Extensions.Configuration;
     using Microsoft.Data.Sqlite;
     using Microsoft.EntityFrameworkCore;
     using System;
@@ -76,17 +77,35 @@ namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
             if (testConfiguration == TestConfiguration.SqlServerRegularTableTypes)
             {
                 context.ManipulationExtensionsConfiguration.SqlServerConfiguration.UseMemoryOptimizedTableTypes = false;
-                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.UseTableValuedParametersParameterCountTreshold = 0;
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.DetaultUseTableValuedParametersParameterCountTreshold = 0;
+            }
+            else if (testConfiguration == TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)
+            {
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.DetaultUseTableValuedParametersParameterCountTreshold = 0;
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntity>(new EntityConifugration { UseMemoryOptimizedTableTypes = false, TableTypeIndex = SqlServerTableTypeIndex.ClusteredIndex });
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntityCompositeKey>(new EntityConifugration { UseMemoryOptimizedTableTypes = false, TableTypeIndex = SqlServerTableTypeIndex.ClusteredIndex });
+            }
+            else if (testConfiguration == TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)
+            {
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.DetaultUseTableValuedParametersParameterCountTreshold = 0;
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntity>(new EntityConifugration { UseMemoryOptimizedTableTypes = false, TableTypeIndex = SqlServerTableTypeIndex.NonClusteredIndex });
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntityCompositeKey>(new EntityConifugration { UseMemoryOptimizedTableTypes = false, TableTypeIndex = SqlServerTableTypeIndex.NonClusteredIndex });
             }
             else if (testConfiguration == TestConfiguration.SqlServerMemoryOptimizedTableTypes)
             {
                 context.ManipulationExtensionsConfiguration.SqlServerConfiguration.UseMemoryOptimizedTableTypes = true;
-                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.UseTableValuedParametersParameterCountTreshold = 0;
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.DetaultUseTableValuedParametersParameterCountTreshold = 0;
+            }
+            else if (testConfiguration == TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)
+            {
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.DetaultUseTableValuedParametersParameterCountTreshold = 0;
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntity>(new EntityConifugration { UseMemoryOptimizedTableTypes = true, TableTypeIndex = SqlServerTableTypeIndex.NonClusteredIndex });
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntityCompositeKey>(new EntityConifugration { UseMemoryOptimizedTableTypes = true, TableTypeIndex = SqlServerTableTypeIndex.NonClusteredIndex });
             }
             else if (testConfiguration == TestConfiguration.SqlServerOutputInto)
             {
-                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.EntityTypesWithTriggers.Add(nameof(TestEntity));
-                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.EntityTypesWithTriggers.Add(nameof(TestEntityCompositeKey));
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntity>(new EntityConifugration { HasTrigger = true });
+                context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestEntityCompositeKey>(new EntityConifugration { HasTrigger = true });
             }
             else if (testConfiguration == TestConfiguration.SqlServerMergeSync)
             {

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/TestConfiguration.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/TestConfiguration.cs
@@ -5,7 +5,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
     {
         Default,
         SqlServerRegularTableTypes,
+        SqlServerRegularTableTypesWithClusteredIndex,
+        SqlServerRegularTableTypesWithNonclusteredIndex,
         SqlServerMemoryOptimizedTableTypes,
+        SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex,
         SqlServerOutputInto,
         SqlServerMergeSync,
         SqlServerSimpleStatementsSync

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/InsertIfNotExistTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/InsertIfNotExistTests.cs
@@ -18,7 +18,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task InsertIfNotExistAsync_ShouldNotInsertEntities_WhenNoEntitiesGiven(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -39,7 +42,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task InsertIfNotExistAsync_ShouldInsertAndReturnAllEntitiest_WhenThereAreNoExistingEntities(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -67,7 +73,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task InsertIfNotExistAsync_ShouldInsertAndReturnEntitiesWhichNotExist_WhenThereAreExistingEntities(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
@@ -19,10 +19,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -48,10 +49,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -85,10 +87,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldUpdateAndReturnEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -120,10 +123,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -157,10 +161,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         [Ignore("Need to fix this case")]
         public async Task SyncAsync_ShouldDeleteAndReturnEntireSource_WhenSourceIsEmpty(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -186,10 +191,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndUpdateAndReturnEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -219,10 +225,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -254,10 +261,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -288,10 +296,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -324,10 +333,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -360,10 +370,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -398,10 +409,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndDeleteAndReturnMatchingTargetEntities_WhenTargetIsEntireTablee(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -436,10 +448,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndDeleteAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -476,10 +489,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -504,10 +518,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -539,10 +554,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -579,10 +595,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -621,10 +638,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -649,10 +667,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -683,10 +702,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldUpdateAndReturnEntities_WhenAllEntitiesMatchInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -721,10 +741,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -761,10 +782,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateIncludedPropertiesAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -825,10 +847,11 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
-        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateNonExcludedPropertiesAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/UpdateTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/UpdateTests.cs
@@ -16,7 +16,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnEmptyCollection_WhenThereAreNoEntitiesInDbNorInput(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -34,7 +37,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnEmptyCollection_WhenThereAreNoEntitiesInInput(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -58,7 +64,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnEmptyCollection_WhenThereAreNoMatchingEntitiesBasedOnKey(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -87,7 +96,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnEmptyCollection_WhenThereAreNoMatchingEntitiesBasedOnCondition(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -117,7 +129,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnUpdatedCollection_WhenAllEntitiesAreMatchingWithoutCondition(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -145,7 +160,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnAffectedUpdatedCollection_WhenASubsetOfEntitiesAreMatchingWithoutCondition(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -175,7 +193,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnAffectedUpdatedCollection_WhenASubsetOfEntitiesAreMatchingWithCondition(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -208,7 +229,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnCollectionWithOnlyIncludedPropertiesUpdated_WhenEntitiesMatchAndIncludedPropertyExpresionsArePassed(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -278,11 +302,13 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
             // We're only using Table Valued Parameters in SqlServer
             using TestDbContext context = await ContextFactory.GetDbContextAsync(DbProvider.SqlServer, seedData: existingEntities);
 
-            // Make sure we're using TVP
-            context.ManipulationExtensionsConfiguration.SqlServerConfiguration.UseTableValuedParametersParameterCountTreshold = 0;
-
-            // Add the test interceptor
-            context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddTableValuedParameterInterceptor<TestInterceptorEntity>(new TestTableValuedParameterInterceptor());
+            // Make sure we're using TVP and add the test interceptor
+            context.ManipulationExtensionsConfiguration.SqlServerConfiguration.AddEntityConifugration<TestInterceptorEntity>(
+                new Configuration.EntityConifugration
+                {
+                    UseTableValuedParametersParameterCountTreshold = 0,
+                    TableValuedParameterInterceptor = new TestTableValuedParameterInterceptor(),
+                });
 
             // Include bool values - they are the only items expected to be updated based on the mocked data.
             InclusionBuilder<TestInterceptorEntity> inclusionBuilder = new InclusionBuilder<TestInterceptorEntity>().Include(x => x.BoolTestValue);
@@ -316,7 +342,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.Sqlite)]
         [DataRow(DbProvider.SqlServer)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
         public async Task UpdateAsync_ShouldReturnCollectionWithOnlyNonExcludedPropertiesUpdated_WhenEntitiesMatchAndIncludedPropertyNamesArePassed(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {

--- a/EntityFrameworkCore.Manipulation.Extensions/Configuration/EntityConifugration.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Configuration/EntityConifugration.cs
@@ -1,0 +1,79 @@
+namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+
+    /// <summary>
+    /// Entity-specific configuration, controlling indexing, use of memory-optimized types, etc. for a given entity.
+    /// </summary>
+    public class EntityConifugration
+    {
+        /// <summary>
+        /// Gets or sets the row threhold for when Table Valued Parameters should be used for the referenced entity.
+        /// When the number of rows in an input collection to any of the extension methods exceeds this number,
+        /// Table Valued Parameters will be used instead of individual parameters.
+        ///
+        /// If <see cref="UseTableValuedParametersParameterCountTreshold"/> is encountered first
+        /// </summary>
+        /// <remarks>If not set, the value for <see cref="SqlServerManipulationExtensionsConfiguration.DefaultUseTableValuedParametersRowTreshold"/> will be used.</remarks>
+        [Range(0, 2000)]
+        public int? UseTableValuedParametersRowTreshold { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parameter count threhold for when Table Valued Parameters should be used for the referenced entity.
+        /// When the number of parameters, each representing a property of an entity in an input collection to
+        /// any of the extension methods exceeds this number, Table Valued Parameters will be used instead of individual parameters.
+        /// </summary>
+        /// <remarks>If not set, the value for <see cref="SqlServerManipulationExtensionsConfiguration.DetaultUseTableValuedParametersParameterCountTreshold"/> will be used.</remarks>
+        [Range(0, 2000)]
+        public int? UseTableValuedParametersParameterCountTreshold { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to create/use memory-optimized (in-memory OLTP) table types when using
+        /// table values parameters for the referenced entity type. Using memory-optimized table types means that the input data
+        /// is stored in memory, rather than in the temp db on disk.
+        /// </summary>
+        /// <remarks>If not set, the value for <see cref="SqlServerManipulationExtensionsConfiguration.UseMemoryOptimizedTableTypes"/> will be used.</remarks>
+        public bool? UseMemoryOptimizedTableTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Hash Index Bucket Count used when creating a Hash Index for a Memory-Optimized Table Type for the referenced entity type.
+        /// The general guidance is for this to be set to 1.5x - 2x the number of estimated max rows used as input to any of
+        /// the extension methods for this lib. You can set the bucket count for individual entity types by utilizing
+        /// <see cref="HashIndexBucketCountsByEntityType"/>. For more information, refer to
+        /// <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/sql-server-index-design-guide?view=sql-server-ver15#configuring_bucket_count"/>.
+        /// </summary>
+        /// <remarks>If not set, the value for <see cref="SqlServerManipulationExtensionsConfiguration.DefaultHashIndexBucketCount"/> will be used.</remarks>
+        public int? HashBucketSizetHashIndexBucketCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the entity type has triggers defined. The library uses OUTPUT statements to return back the
+        /// modified data. The OUTPUT statement does not work out-of-box with triggers; the output has to be placed into a temp table and then return.
+        /// By registering an entity type here, that's what will happen. Note that if the trigger on an entity modifies the effected entities,
+        /// the latest state of the entity will not be returned. Only the output from the actual library operation will be returned.
+        /// </summary>
+        public bool HasTrigger { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to utilize SQL Server's MERGE statement for upserts and syncs, or whether to
+        /// used individual INSERT, UPDATE, and DELETE statements for the referenced entity type.. The merge statement may increase performance for upserts and syncs,
+        /// especially in regards to IO. It may also decrease performance in certain cases. This setting allows the consumer of the
+        /// library to test which use cases is best for their specific scenario.
+        /// </summary>
+        /// <remarks>If not set, the value for <see cref="SqlServerManipulationExtensionsConfiguration.UseMerge"/> will be used.</remarks>
+        public bool? UseMerge { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating what type of index to use for the table type uses for table-valued parameters for the
+        /// referenced entity type.
+        /// </summary>
+        /// <remarks>If not set, the value for <see cref="SqlServerManipulationExtensionsConfiguration.DefaultTableTypeIndex"/> will be used.</remarks>
+        public SqlServerTableTypeIndex? TableTypeIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the interceptor to be used when processing the type of entity. The interceptor can be used to re-configure
+        /// the table type schema definition before the type is being created.
+        /// </summary>
+        public ITableValuedParameterInterceptor TableValuedParameterInterceptor { get; set; }
+    }
+}

--- a/EntityFrameworkCore.Manipulation.Extensions/Configuration/Internal/SqlServerManipulationExtensionsConfigurationExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Configuration/Internal/SqlServerManipulationExtensionsConfigurationExtensions.cs
@@ -2,21 +2,50 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Configuration.Internal
 {
     using System;
     using System.Collections.Generic;
+    using EntityFrameworkCore.Manipulation.Extensions.Internal;
     using Microsoft.EntityFrameworkCore.Metadata;
 
-    public static class SqlServerManipulationExtensionsConfigurationExtensions
+    internal static class SqlServerManipulationExtensionsConfigurationExtensions
     {
+        public static bool DoesEntityHaveTriggers<TEntity>(this SqlServerManipulationExtensionsConfiguration configuration) =>
+            configuration.GetEntityConifugrationOrDefault<TEntity>()?.HasTrigger ?? false;
+
+        public static int GetHashIndexBucketCount(this SqlServerManipulationExtensionsConfiguration configuration, Type entityType) =>
+            configuration.GetEntityConifugrationOrDefault(entityType)?.HashBucketSizetHashIndexBucketCount ?? configuration.DefaultHashIndexBucketCount;
+
+        public static SqlServerTableTypeIndex GetTableTypeIndex(this SqlServerManipulationExtensionsConfiguration configuration, Type entityType) =>
+            configuration.GetEntityConifugrationOrDefault(entityType)?.TableTypeIndex ?? configuration.DefaultTableTypeIndex;
+
+        public static ITableValuedParameterInterceptor GetTvpInterceptor(this SqlServerManipulationExtensionsConfiguration configuration, Type entityType) =>
+            configuration.GetEntityConifugrationOrDefault(entityType)?.TableValuedParameterInterceptor ?? DefaultTableValuedParameterInterceptor.Instance;
+
         public static bool ShouldUseTableValuedParameters<TEntity>(
-            this SqlServerManipulationExtensionsConfiguration confiruation,
+            this SqlServerManipulationExtensionsConfiguration configuration,
             IReadOnlyCollection<IProperty> properties,
             IReadOnlyCollection<TEntity> entities)
         {
-            if (confiruation == null)
+            if (configuration == null)
             {
-                throw new ArgumentNullException(nameof(confiruation));
+                throw new ArgumentNullException(nameof(configuration));
             }
 
-            return entities.Count > confiruation.UseTableValuedParametersRowTreshold || entities.Count * properties.Count > confiruation.UseTableValuedParametersParameterCountTreshold;
+            EntityConifugration entityConfiguration = configuration.GetEntityConifugrationOrDefault<TEntity>();
+            int rowThreshold = entityConfiguration?.UseTableValuedParametersRowTreshold ?? configuration.DefaultUseTableValuedParametersRowTreshold;
+            int parameterThreshold = entityConfiguration?.UseTableValuedParametersParameterCountTreshold ?? configuration.DetaultUseTableValuedParametersParameterCountTreshold;
+
+            return entities.Count > rowThreshold || entities.Count * properties.Count > parameterThreshold;
         }
+
+        public static bool ShouldUseMemoryOptimizedTableTypes(this SqlServerManipulationExtensionsConfiguration configuration, Type entityType) =>
+            configuration.GetEntityConifugrationOrDefault(entityType)?.UseMemoryOptimizedTableTypes ?? configuration.UseMemoryOptimizedTableTypes;
+
+        public static bool ShouldUseMerge<TEntity>(this SqlServerManipulationExtensionsConfiguration configuration) =>
+            configuration.GetEntityConifugrationOrDefault<TEntity>()?.UseMerge ?? configuration.UseMerge;
+
+        private static EntityConifugration GetEntityConifugrationOrDefault<TEntity>(this SqlServerManipulationExtensionsConfiguration configuration) =>
+            configuration.GetEntityConifugrationOrDefault(typeof(TEntity));
+
+        private static EntityConifugration GetEntityConifugrationOrDefault(this SqlServerManipulationExtensionsConfiguration configuration, Type entityType) =>
+            configuration.EntityConfigurations.TryGetValue(entityType, out EntityConifugration entityConifugration) ? entityConifugration : null;
     }
 }

--- a/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerManipulationExtensionsConfiguration.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerManipulationExtensionsConfiguration.cs
@@ -14,10 +14,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
         /// When the number of rows in an input collection to any of the extension methods exceeds this number,
         /// Table Valued Parameters will be used instead of individual parameters.
         ///
-        /// If <see cref="UseTableValuedParametersParameterCountTreshold"/> is encountered first
+        /// If <see cref="DetaultUseTableValuedParametersParameterCountTreshold"/> is encountered first
         /// </summary>
         [Range(0, 2000)]
-        public int UseTableValuedParametersRowTreshold { get; set; } = 50;
+        public int DefaultUseTableValuedParametersRowTreshold { get; set; } = 50;
 
         /// <summary>
         /// Gets or sets the parameter count threhold for when Table Valued Parameters should be used.
@@ -25,12 +25,12 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
         /// any of the extension methods exceeds this number, Table Valued Parameters will be used instead of individual parameters.
         /// </summary>
         [Range(0, 2000)]
-        public int UseTableValuedParametersParameterCountTreshold { get; set; } = 500;
+        public int DetaultUseTableValuedParametersParameterCountTreshold { get; set; } = 500;
 
         /// <summary>
         /// Gets or sets a value indicating whether to create/use memory-optimized (in-memory OLTP) table types when using
         /// table values parameters. Using memory-optimized table types means that the input data is stored in memory, rather
-        /// than in the temp db on disk. This option
+        /// than in the temp db on disk.
         /// </summary>
         public bool UseMemoryOptimizedTableTypes { get; set; } = true;
 
@@ -44,39 +44,28 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
         public int DefaultHashIndexBucketCount { get; set; } = 1000;
 
         /// <summary>
-        /// Gets a dictionary of Hash Index Bucket Counts to Entitiy Types. This can be used to specifiy the Bucket Count
-        /// when creating a Hash Index for a Memory-Optimized Table Type for a specific Entity Type. If a count for a given type
-        /// is not set, the <see cref="DefaultHashIndexBucketCount"/> will be used. The general guidance is for this to be set to
-        /// 1.5x - 2x the number of estimated max rows used as input to any of the extension methods for this lib. For more information, refer to
-        /// <see cref="https://docs.microsoft.com/en-us/sql/relational-databases/sql-server-index-design-guide?view=sql-server-ver15#configuring_bucket_count"/>.
-        /// </summary>
-        public Dictionary<string, int> HashIndexBucketCountsByEntityType { get; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// Gets a collection of the entity types which have triggers defined. The library uses OUTPUT statements to return back the
-        /// modified data. The OUTPUT statement does not work out-of-box with triggers; the output has to be placed into a temp table and then return.
-        /// By registering an entity type here, that's what will happen. Note that if the trigger on an entity modifies the effected entities,
-        /// the latest state of the entity will not be returned. Only the output from the actual library operation will be returned.
-        /// </summary>
-        public ISet<string> EntityTypesWithTriggers { get; } = new HashSet<string>();
-
-        internal Dictionary<Type, ITableValuedParameterInterceptor> TvpInterceptors { get; } = new Dictionary<Type, ITableValuedParameterInterceptor>();
-
-        /// <summary>
-        /// Registers the <paramref name="interceptor"/> to be used when processing <typeparamref name="TEntity"/> entities.
-        /// </summary>
-        /// <typeparam name="TEntity">The type of entity to intercept.</typeparam>
-        /// <param name="interceptor">An interceptor instance.</param>
-        /// <returns><c>true</c> if there was already an interceptor registered for <typeparamref name="TEntity"/>, <c>false</c> otherwise.</returns>
-        public bool AddTableValuedParameterInterceptor<TEntity>(ITableValuedParameterInterceptor interceptor) =>
-            this.TvpInterceptors.TryAdd(typeof(TEntity), interceptor ?? throw new ArgumentNullException(nameof(interceptor)));
-
-        /// <summary>
         /// Gets or sets a value indicating whether to utilize SQL Server's MERGE statement for upserts and syncs, or whether to
         /// used individual INSERT, UPDATE, and DELETE statements. The merge statement may increase performance for upserts and syncs,
         /// especially in regards to IO. It may also decrease performance in certain cases. This setting allows the consumer of the
         /// library to test which use cases is best for their specific scenario.
         /// </summary>
         public bool UseMerge { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the default for what type of index to use for the table type uses for table-valued parameters.
+        /// </summary>
+        public SqlServerTableTypeIndex DefaultTableTypeIndex { get; set; } = SqlServerTableTypeIndex.Default;
+
+        internal IDictionary<Type, EntityConifugration> EntityConfigurations { get; } = new Dictionary<Type, EntityConifugration>();
+
+        /// <summary>
+        /// Adds configuration specific for a given type of <typeparamref name="TEntity"/>. This can be used to control
+        /// settings on an entity-level.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of entity.</typeparam>
+        /// <param name="entityConifugration">The entity-specific configuration.</param>
+        /// <returns>True if the configuration was added, false if it was already present.</returns>
+        public bool AddEntityConifugration<TEntity>(EntityConifugration entityConifugration) =>
+            this.EntityConfigurations.TryAdd(typeof(TEntity), entityConifugration ?? throw new ArgumentNullException(nameof(entityConifugration)));
     }
 }

--- a/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerTableTypeIndex.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Configuration/SqlServerTableTypeIndex.cs
@@ -1,0 +1,31 @@
+namespace EntityFrameworkCore.Manipulation.Extensions.Configuration
+{
+    public enum SqlServerTableTypeIndex
+    {
+        /// <summary>
+        /// Default. For a non-memory optimized table type, this defaults to <see cref="NoIndex"/>.
+        /// For a memory-optimized table type, this defaults to <see cref="HashIndex"/>
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// No index. Only available on non-memory optimized table types.
+        /// </summary>
+        NoIndex = 1,
+
+        /// <summary>
+        /// Clustered index.
+        /// </summary>
+        ClusteredIndex = 2,
+
+        /// <summary>
+        /// Non-clustered index.
+        /// </summary>
+        NonClusteredIndex = 3,
+
+        /// <summary>
+        /// Hash index.
+        /// </summary>
+        HashIndex = 4
+    }
+}

--- a/EntityFrameworkCore.Manipulation.Extensions/InsertIfNotExistExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/InsertIfNotExistExtensions.cs
@@ -70,7 +70,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             }
             else
             {
-                bool outputInto = configuration.SqlServerConfiguration.EntityTypesWithTriggers.Contains(entityType.ClrType.Name);
+                bool outputInto = configuration.SqlServerConfiguration.DoesEntityHaveTriggers<TEntity>();
 
                 string userDefinedTableTypeName = null;
                 if (configuration.SqlServerConfiguration.ShouldUseTableValuedParameters(properties, entities) || outputInto)

--- a/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
@@ -284,9 +284,9 @@ namespace EntityFrameworkCore.Manipulation.Extensions
         {
             ManipulationExtensionsConfiguration configuration = dbContext.GetConfiguration();
 
-            if (configuration.SqlServerConfiguration.UseMerge)
+            if (configuration.SqlServerConfiguration.ShouldUseMerge<TEntity>())
             {
-                bool outputInto = configuration.SqlServerConfiguration.EntityTypesWithTriggers.Contains(entityType.ClrType.Name);
+                bool outputInto = configuration.SqlServerConfiguration.DoesEntityHaveTriggers<TEntity>();
                 string userDefinedTableTypeName = null;
                 if (configuration.SqlServerConfiguration.ShouldUseTableValuedParameters(properties, source))
                 {

--- a/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
@@ -126,7 +126,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             }
             else
             {
-                bool outputInto = configuration.SqlServerConfiguration.EntityTypesWithTriggers.Contains(entityType.ClrType.Name);
+                bool outputInto = configuration.SqlServerConfiguration.DoesEntityHaveTriggers<TEntity>();
 
                 string userDefinedTableTypeName = null;
                 if (configuration.SqlServerConfiguration.ShouldUseTableValuedParameters(properties, source) || outputInto)


### PR DESCRIPTION
This changes introduces support for configuring settings on an entity-level. Consumers of the lib can now for example set whether to use merge or whether use memory-optimized table types for a specific entity type.

In addition, it also introduces configurations for the consumer to select the index type on table types. The default for regular (disk-based) table types is to have no index. The default for memory-optimized table types is to use a Hash index.