### PR TITLE
Adds resolver-based targets for sync

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
@@ -24,6 +24,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -54,6 +56,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -92,6 +96,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldUpdateAndReturnEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -128,6 +134,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -166,6 +174,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         [Ignore("Need to fix this case")]
         public async Task SyncAsync_ShouldDeleteAndReturnEntireSource_WhenSourceIsEmpty(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
@@ -196,6 +206,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndUpdateAndReturnEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -230,6 +242,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -266,6 +280,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -301,6 +317,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -338,6 +356,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -375,6 +395,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -414,6 +436,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndDeleteAndReturnMatchingTargetEntities_WhenTargetIsEntireTablee(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -453,6 +477,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncAsync_ShouldInsertAndUpdateAndDeleteAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -494,6 +520,55 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
+        public async Task SyncAsync_ShouldInsertAndUpdateAndDeleteAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTableDeterminedByResolver(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
+        {
+            TestEntityCompositeKey[] existingEntities = new[]
+            {
+                new TestEntityCompositeKey { IdPartA = "MATCH 1", IdPartB = "TO BE DELETED", IntTestValue = 111, BoolTestValue = true, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 65465132165 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 1", IdPartB = "Should Be Updated", IntTestValue = 222, BoolTestValue = true, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 5641324 },
+                new TestEntityCompositeKey { IdPartA = "ExcludedEntity", IdPartB = "E1", IntTestValue = 165, BoolTestValue = true, DateTimeTestValue = new DateTime(998416312), LongTestValue = 135431 },
+                new TestEntityCompositeKey { IdPartA = "ExcludedEntity", IdPartB = "E2", IntTestValue = 98116, BoolTestValue = false, DateTimeTestValue = new DateTime(896513433), LongTestValue = -4564 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 2", IdPartB = "TO BE DELETED", IntTestValue = 444, BoolTestValue = false, DateTimeTestValue = new DateTime(55644547416541), LongTestValue = 89413543521 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 2", IdPartB = "Should Be Updated", IntTestValue = 333, BoolTestValue = true, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 1354126 },
+            };
+            using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, existingEntities, testConfiguration: testConfiguration);
+
+            TestEntityCompositeKey[] expectedEntitiesInTargetAfterSync = new[]
+            {
+                new TestEntityCompositeKey { IdPartA = "TO BE INSERTED", IdPartB = "1", IntTestValue = 84106, BoolTestValue = true, DateTimeTestValue = new DateTime(846213546), LongTestValue = 32425123 },
+                new TestEntityCompositeKey { IdPartA = "TO BE INSERTED", IdPartB = "2", IntTestValue = 87132, BoolTestValue = false, DateTimeTestValue = new DateTime(81846213546), LongTestValue = 87421354 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 1", IdPartB = "Should Be Updated", IntTestValue = 9932165, BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 5641324 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 2", IdPartB = "Should Be Updated", IntTestValue = 985613, BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 5641324 },
+            };
+
+            // Invoke the method and check that the result is the expected entities
+            ISyncResult<TestEntityCompositeKey> result = await context.SyncAsync(
+                targetResolver: x => x.target.Where(targetEntry => x.source.Any(sourceEntry => targetEntry.IdPartA == sourceEntry.IdPartA)),
+                expectedEntitiesInTargetAfterSync);
+
+            result.DeletedEntities.Should().BeEquivalentTo(existingEntities.Where(e => e.IdPartB == "TO BE DELETED"));
+            result.InsertedEntities.Should().BeEquivalentTo(expectedEntitiesInTargetAfterSync.Where(e => e.IdPartA == "TO BE INSERTED"));
+            result.UpdatedEntities.Should().BeEquivalentTo(new[] { (existingEntities[1], expectedEntitiesInTargetAfterSync[2]), (existingEntities[5], expectedEntitiesInTargetAfterSync[3]) });
+
+            // Then check that the the changes were synced to the db
+            context.TestEntitiesWithCompositeKey.ToList().Should().BeEquivalentTo(
+                existingEntities.Where(e => e.IdPartA == "ExcludedEntity") // Existing excluded entities (excluded by the target resolver)
+                .Concat(expectedEntitiesInTargetAfterSync)); // + synced entries
+        }
+
+        [DataTestMethod]
+        [DataRow(DbProvider.Sqlite)]
+        [DataRow(DbProvider.SqlServer)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -523,6 +598,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -559,6 +636,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -600,6 +679,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task SyncWithoutUpdateAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -643,6 +724,54 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
+        public async Task SyncWithoutUpdateAsync_ShouldDeleteAndInsertAndReturnMatchingTargetEntities_WhenTargetIsSubsetOfTableDeterminedByResolver(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
+        {
+            // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
+            TestEntityCompositeKey[] existingEntities = new[]
+            {
+                new TestEntityCompositeKey { IdPartA = "MATCH 1", IdPartB = "TO BE DELETED", IntTestValue = 111, BoolTestValue = true, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 65465132165 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 1", IdPartB = "Should Be Ignored", IntTestValue = 222, BoolTestValue = true, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 5641324 },
+                new TestEntityCompositeKey { IdPartA = "ExcludedEntity", IdPartB = "E1", IntTestValue = 165, BoolTestValue = true, DateTimeTestValue = new DateTime(998416312), LongTestValue = 135431 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 2", IdPartB = "TO BE DELETED", IntTestValue = 444, BoolTestValue = false, DateTimeTestValue = new DateTime(55644547416541), LongTestValue = 89413543521 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 2", IdPartB = "Should Be Ignored", IntTestValue = 333, BoolTestValue = true, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 1354126 },
+            };
+            using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, existingEntities, testConfiguration: testConfiguration);
+
+            TestEntityCompositeKey[] expectedEntitiesInTargetAfterSync = new[]
+            {
+                new TestEntityCompositeKey { IdPartA = "TO BE INSERTED", IdPartB = "1", IntTestValue = 84106, BoolTestValue = true, DateTimeTestValue = new DateTime(846213546), LongTestValue = 32425123 },
+                new TestEntityCompositeKey { IdPartA = "TO BE INSERTED", IdPartB = "2", IntTestValue = 87132, BoolTestValue = false, DateTimeTestValue = new DateTime(81846213546), LongTestValue = 87421354 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 1", IdPartB = "Should Be Ignored", IntTestValue = 9932165, BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 5641324 },
+                new TestEntityCompositeKey { IdPartA = "MATCH 2", IdPartB = "Should Be Ignored", IntTestValue = 985613, BoolTestValue = false, DateTimeTestValue = DateTime.UtcNow, LongTestValue = 5641324 },
+            };
+
+            // Invoke the method and check that the result is the expected entities
+            ISyncWithoutUpdateResult<TestEntityCompositeKey> result = await context.SyncWithoutUpdateAsync(
+                targetResolver: x => x.target.Where(targetEntry => x.source.Any(sourceEntry => targetEntry.IdPartA == sourceEntry.IdPartA)),
+                expectedEntitiesInTargetAfterSync);
+
+            result.DeletedEntities.Should().BeEquivalentTo(existingEntities.Where(e => e.IdPartB == "TO BE DELETED"));
+            result.InsertedEntities.Should().BeEquivalentTo(expectedEntitiesInTargetAfterSync.Where(e => e.IdPartA == "TO BE INSERTED"));
+
+            // Then check that the the changes were synced to the db
+            context.TestEntitiesWithCompositeKey.ToList().Should().BeEquivalentTo(
+                existingEntities.Where(e => e.IdPartB == "Should Be Ignored" || e.IdPartA == "ExcludedEntity") // Existing matched entities (ignored) + excluded entities (excluded by the target resolver)
+                .Concat(expectedEntitiesInTargetAfterSync.Where(e => e.IdPartA.StartsWith("TO BE INSERTED", StringComparison.Ordinal)))); // new entries
+        }
+
+        [DataTestMethod]
+        [DataRow(DbProvider.Sqlite)]
+        [DataRow(DbProvider.SqlServer)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMemoryOptimizedTableTypesWithNonclusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypes)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndReturnEntities_WhenNoEntitiesExist(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             using TestDbContext context = await ContextFactory.GetDbContextAsync(provider, seedData: null, testConfiguration: testConfiguration); // Note: no seed data => no entities exist
@@ -672,6 +801,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndReturnEntities_WhenNoMatchingEntitiesExistInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -707,6 +838,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldUpdateAndReturnEntities_WhenAllEntitiesMatchInTarget(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             TestEntity[] existingEntities = new[]
@@ -746,6 +879,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -787,6 +922,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateIncludedPropertiesAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact
@@ -852,6 +989,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithClusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerRegularTableTypesWithNonclusteredIndex)]
         [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerOutputInto)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerSimpleStatementsSync)]
+        [DataRow(DbProvider.SqlServer, TestConfiguration.SqlServerMergeSync)]
         public async Task UpsertAsync_ShouldInsertAndUpdateNonExcludedPropertiesAndReturnMatchingTargetEntities_WhenTargetIsEntireTable(DbProvider provider, TestConfiguration testConfiguration = TestConfiguration.Default)
         {
             // Note: SyncWithoutUpdate ignores matched items, i.e. it doesn't update them. As such, we expected them to stay intact

--- a/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
@@ -22,12 +22,12 @@ namespace EntityFrameworkCore.Manipulation.Extensions
         /// Syncs the <paramref name="source"/> entities into the <paramref name="target"/> queryable. This entails:
         /// 1. Inserting any entities which exist in source, but not in target, into target
         /// 2. Updating the properties of any entities which exist in both source and target to the values found in source
-        /// 3. Deleting any entities in target which do not exist in targets.
+        /// 3. Deleting any entities in target which do not exist in source.
         ///
         /// This operation performs a full sync (also known as MERGE), and is to be used in scenarios where a target should replicate
         /// the source. For situations that do not require deletion, use
         /// <see cref="UpsertAsync{TEntity}(DbContext, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>
-        /// and for scenarios which do not require updates, use <see cref="SyncAsync{TEntity}(DbContext, IQueryable{TEntity}, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>.
+        /// and for scenarios which do not require updates, use <see cref="SyncWithoutUpdateAsync{TEntity}(DbContext, IQueryable{TEntity}, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// The <paramref name="target"/> should be selected with care as any entities not matched in <paramref name="source"/> will be deleted from the target.
@@ -59,7 +59,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
         /// Syncs the <paramref name="source"/> entities into the a target. This entails:
         /// 1. Inserting any entities which exist in source, but not in target, into target
         /// 2. Updating the properties of any entities which exist in both source and target to the values found in source
-        /// 3. Deleting any entities in target which do not exist in targets.
+        /// 3. Deleting any entities in target which do not exist in source.
         ///
         /// The target is the queryable returned by the <paramref name="targetResolver"/>. You may use the source queryable, passed into the resolver,
         /// to specify the target queryable to return.
@@ -67,7 +67,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
         /// This operation performs a full sync (also known as MERGE), and is to be used in scenarios where a target should replicate
         /// the source. For situations that do not require deletion, use
         /// <see cref="UpsertAsync{TEntity}(DbContext, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>
-        /// and for scenarios which do not require updates, use <see cref="SyncAsync{TEntity}(DbContext, IQueryable{TEntity}, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>.
+        /// and for scenarios which do not require updates, use <see cref="SyncWithoutUpdateAsync{TEntity}(DbContext, Func{(IQueryable{TEntity} source, IQueryable{TEntity} target), IQueryable{TEntity}}, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// The <paramref name="targetResolver"/> should be specified with care as any entities not matched in <paramref name="source"/> will be deleted from the target.
@@ -107,7 +107,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
         /// <summary>
         /// Syncs the <paramref name="source"/> entities into the <paramref name="target"/> queryable, without updating matched entities. This entails:
         /// 1. Inserting any entities which exist in source, but not in target, into target
-        /// 2. Deleting any entities in target which do not exist in targets.
+        /// 2. Deleting any entities in target which do not exist in source.
         /// </summary>
         /// <remarks>
         /// The <paramref name="target"/> should be selected with care as any entities not matched in <paramref name="source"/> will be deleted from the target.
@@ -137,7 +137,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
         /// <summary>
         /// Syncs the <paramref name="source"/> entities into a target, without updating matched entities. This entails:
         /// 1. Inserting any entities which exist in source, but not in target, into target
-        /// 2. Deleting any entities in target which do not exist in targets.
+        /// 2. Deleting any entities in target which do not exist in source.
         ///
         /// The target is the queryable returned by the <paramref name="targetResolver"/>. You may use the source queryable, passed into the resolver,
         /// to specify the target queryable to return.

--- a/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
@@ -18,11 +18,36 @@ namespace EntityFrameworkCore.Manipulation.Extensions
     /// </summary>
     public static class SyncExtensions
     {
+        /// <summary>
+        /// Syncs the <paramref name="source"/> entities into the <paramref name="target"/> queryable. This entails:
+        /// 1. Inserting any entities which exist in source, but not in target, into target
+        /// 2. Updating the properties of any entities which exist in both source and target to the values found in source
+        /// 3. Deleting any entities in target which do not exist in targets.
+        ///
+        /// This operation performs a full sync (also known as MERGE), and is to be used in scenarios where a target should replicate
+        /// the source. For situations that do not require deletion, use
+        /// <see cref="UpsertAsync{TEntity}(DbContext, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>
+        /// and for scenarios which do not require updates, use <see cref="SyncAsync{TEntity}(DbContext, IQueryable{TEntity}, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="target"/> should be selected with care as any entities not matched in <paramref name="source"/> will be deleted from the target.
+        /// If you're only interesting in syncing a subset, make sure to filter/scope down the <paramref name="target"/> to meet your needs before passing it in.
+        /// If you want to sync an entire table, simply pass the <see cref="DbSet{TEntity}"/> for your entity type, but note that this will delete any entities not found in source.
+        /// </remarks>
+        /// <typeparam name="TEntity">The entity type.</typeparam>
+        /// <param name="dbContext">EF Db Context</param>
+        /// <param name="target">The target to be synced to. Specify a queryable based on the <see cref="DbSet{TEntity}"/> of your entity type. Specify with care.</param>
+        /// <param name="source">The collection of entities to sync from.</param>
+        /// <param name="insertClusivityBuilder">The clusivity builder for entities which will be inserted.</param>
+        /// <param name="updateClusivityBuilder">The clusivity builder for entities which will be updated. You may use this to only update a subset of properties.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the sync, containing which entities were inserted, updated, and deleted.</returns>
         public static async Task<ISyncResult<TEntity>> SyncAsync<TEntity>(this DbContext dbContext, IQueryable<TEntity> target, IReadOnlyCollection<TEntity> source, IClusivityBuilder<TEntity> insertClusivityBuilder = null, IClusivityBuilder<TEntity> updateClusivityBuilder = null, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             => await SyncInternalAsync(
                 dbContext ?? throw new ArgumentNullException(nameof(dbContext)),
                 target ?? throw new ArgumentNullException(nameof(target)),
+                targetResolver: null,
                 source ?? throw new ArgumentNullException(nameof(source)),
                 ignoreUpdates: false, // this is a full sync
                 ignoreDeletions: false,
@@ -30,11 +55,78 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                 updateClusivityBuilder,
                 cancellationToken);
 
+        /// <summary>
+        /// Syncs the <paramref name="source"/> entities into the a target. This entails:
+        /// 1. Inserting any entities which exist in source, but not in target, into target
+        /// 2. Updating the properties of any entities which exist in both source and target to the values found in source
+        /// 3. Deleting any entities in target which do not exist in targets.
+        ///
+        /// The target is the queryable returned by the <paramref name="targetResolver"/>. You may use the source queryable, passed into the resolver,
+        /// to specify the target queryable to return.
+        ///
+        /// This operation performs a full sync (also known as MERGE), and is to be used in scenarios where a target should replicate
+        /// the source. For situations that do not require deletion, use
+        /// <see cref="UpsertAsync{TEntity}(DbContext, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>
+        /// and for scenarios which do not require updates, use <see cref="SyncAsync{TEntity}(DbContext, IQueryable{TEntity}, IReadOnlyCollection{TEntity}, IClusivityBuilder{TEntity}, IClusivityBuilder{TEntity}, CancellationToken)"/>.
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="targetResolver"/> should be specified with care as any entities not matched in <paramref name="source"/> will be deleted from the target.
+        /// If you're only interesting in syncing a subset, make sure to filter/scope down the tarfet to meet your needs before passing it in.
+        /// If you want to sync an entire table, simply pass the <see cref="DbSet{TEntity}"/> for your entity type, but note that this will delete any entities not found in source.
+        /// </remarks>
+        /// <typeparam name="TEntity">The entity type.</typeparam>
+        /// <param name="dbContext">EF Db Context</param>
+        /// <param name="targetResolver">
+        /// The resolver for the target. The <see cref="IQueryable{T}"/> returned by the resolver is used as the target. You may base the target on the
+        /// target passed as input, and the source passed as input (e.g. by joining).
+        /// </param>
+        /// <param name="source">The collection of entities to sync from.</param>
+        /// <param name="insertClusivityBuilder">The clusivity builder for entities which will be inserted.</param>
+        /// <param name="updateClusivityBuilder">The clusivity builder for entities which will be updated. You may use this to only update a subset of properties.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the sync, containing which entities were inserted, updated, and deleted.</returns>
+        public static async Task<ISyncResult<TEntity>> SyncAsync<TEntity>(
+            this DbContext dbContext,
+            Func<(IQueryable<TEntity> source, IQueryable<TEntity> target), IQueryable<TEntity>> targetResolver,
+            IReadOnlyCollection<TEntity> source,
+            IClusivityBuilder<TEntity> insertClusivityBuilder = null,
+            IClusivityBuilder<TEntity> updateClusivityBuilder = null,
+            CancellationToken cancellationToken = default)
+            where TEntity : class, new()
+            => await SyncInternalAsync(
+                dbContext ?? throw new ArgumentNullException(nameof(dbContext)),
+                target: null,
+                targetResolver ?? throw new ArgumentNullException(nameof(targetResolver)),
+                source ?? throw new ArgumentNullException(nameof(source)),
+                ignoreUpdates: false, // this is a full sync
+                ignoreDeletions: false,
+                insertClusivityBuilder,
+                updateClusivityBuilder,
+                cancellationToken);
+
+        /// <summary>
+        /// Syncs the <paramref name="source"/> entities into the <paramref name="target"/> queryable, without updating matched entities. This entails:
+        /// 1. Inserting any entities which exist in source, but not in target, into target
+        /// 2. Deleting any entities in target which do not exist in targets.
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="target"/> should be selected with care as any entities not matched in <paramref name="source"/> will be deleted from the target.
+        /// If you're only interesting in syncing a subset, make sure to filter/scope down the <paramref name="target"/> to meet your needs before passing it in.
+        /// If you want to sync an entire table, simply pass the <see cref="DbSet{TEntity}"/> for your entity type, but note that this will delete any entities not found in source.
+        /// </remarks>
+        /// <typeparam name="TEntity">The entity type.</typeparam>
+        /// <param name="dbContext">EF Db Context</param>
+        /// <param name="target">The target to be synced to. Specify a queryable based on the <see cref="DbSet{TEntity}"/> of your entity type. Specify with care.</param>
+        /// <param name="source">The collection of entities to sync from.</param>
+        /// <param name="insertClusivityBuilder">The clusivity builder for entities which will be inserted.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the sync, containing which entities were inserted and deleted.</returns>
         public static async Task<ISyncWithoutUpdateResult<TEntity>> SyncWithoutUpdateAsync<TEntity>(this DbContext dbContext, IQueryable<TEntity> target, IReadOnlyCollection<TEntity> source, IClusivityBuilder<TEntity> insertClusivityBuilder = null, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             => await SyncInternalAsync(
                 dbContext ?? throw new ArgumentNullException(nameof(dbContext)),
                 target ?? throw new ArgumentNullException(nameof(target)),
+                targetResolver: null,
                 source ?? throw new ArgumentNullException(nameof(source)),
                 ignoreUpdates: true, // this is a sync without updates
                 ignoreDeletions: false,
@@ -42,11 +134,65 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                 null,
                 cancellationToken);
 
+        /// <summary>
+        /// Syncs the <paramref name="source"/> entities into a target, without updating matched entities. This entails:
+        /// 1. Inserting any entities which exist in source, but not in target, into target
+        /// 2. Deleting any entities in target which do not exist in targets.
+        ///
+        /// The target is the queryable returned by the <paramref name="targetResolver"/>. You may use the source queryable, passed into the resolver,
+        /// to specify the target queryable to return.
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="targetResolver"/> should be specified with care as any entities not matched in <paramref name="source"/> will be deleted from the target.
+        /// If you're only interesting in syncing a subset, make sure to filter/scope down the tarfet to meet your needs before passing it in.
+        /// If you want to sync an entire table, simply pass the <see cref="DbSet{TEntity}"/> for your entity type, but note that this will delete any entities not found in source.
+        /// </remarks>
+        /// <typeparam name="TEntity">The entity type.</typeparam>
+        /// <param name="dbContext">EF Db Context</param>
+        /// <param name="targetResolver">
+        /// The resolver for the target. The <see cref="IQueryable{T}"/> returned by the resolver is used as the target. You may base the target on the
+        /// target passed as input, and the source passed as input (e.g. by joining).
+        /// </param>
+        /// <param name="source">The collection of entities to sync from.</param>
+        /// <param name="insertClusivityBuilder">The clusivity builder for entities which will be inserted.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the sync, containing which entities were inserted and deleted.</returns>
+        public static async Task<ISyncWithoutUpdateResult<TEntity>> SyncWithoutUpdateAsync<TEntity>(
+            this DbContext dbContext,
+            Func<(IQueryable<TEntity> source, IQueryable<TEntity> target), IQueryable<TEntity>> targetResolver,
+            IReadOnlyCollection<TEntity> source,
+            IClusivityBuilder<TEntity> insertClusivityBuilder = null,
+            CancellationToken cancellationToken = default)
+            where TEntity : class, new()
+            => await SyncInternalAsync(
+                dbContext ?? throw new ArgumentNullException(nameof(dbContext)),
+                target: null,
+                targetResolver ?? throw new ArgumentNullException(nameof(targetResolver)),
+                source ?? throw new ArgumentNullException(nameof(source)),
+                ignoreUpdates: true, // this is a sync without updates
+                ignoreDeletions: false,
+                insertClusivityBuilder,
+                null,
+                cancellationToken);
+
+        /// <summary>
+        /// Upserts the <paramref name="source"/> into the <typeparamref name="TEntity"/>'s <see cref="DbSet{TEntity}"/>. This entails:
+        /// 1. Inserting any entities which exist in source, but does not exist in the database.
+        /// 2. Updating the properties of any entities which exist in both source and the database to the values found in source
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type.</typeparam>
+        /// <param name="dbContext">EF Db Context</param>
+        /// <param name="source">The collection of entities to upsert from.</param>
+        /// <param name="insertClusivityBuilder">The clusivity builder for entities which will be inserted.</param>
+        /// <param name="updateClusivityBuilder">The clusivity builder for entities which will be updated. You may use this to only update a subset of properties.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The result of the upsert, containing which entities were inserted and updated.</returns>
         public static async Task<IUpsertResult<TEntity>> UpsertAsync<TEntity>(this DbContext dbContext, IReadOnlyCollection<TEntity> source, IClusivityBuilder<TEntity> insertClusivityBuilder = null, IClusivityBuilder<TEntity> updateClusivityBuilder = null, CancellationToken cancellationToken = default)
             where TEntity : class, new()
             => await SyncInternalAsync(
                 dbContext ?? throw new ArgumentNullException(nameof(dbContext)),
-                dbContext.Set<TEntity>(),
+                target: dbContext.Set<TEntity>(),
+                targetResolver: null,
                 source ?? throw new ArgumentNullException(nameof(source)),
                 ignoreUpdates: false,
                 ignoreDeletions: true, // this is a sync for upserts
@@ -57,6 +203,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
         private static async Task<SyncResult<TEntity>> SyncInternalAsync<TEntity>(
             this DbContext dbContext,
             IQueryable<TEntity> target,
+            Func<(IQueryable<TEntity> source, IQueryable<TEntity> target), IQueryable<TEntity>> targetResolver,
             IReadOnlyCollection<TEntity> source,
             bool ignoreUpdates,
             bool ignoreDeletions,
@@ -76,16 +223,16 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             IProperty[] propertiesToUpdate = updateClusivityBuilder == null ? nonPrimaryKeyProperties : updateClusivityBuilder.Build(nonPrimaryKeyProperties);
             IProperty[] propertiesToInsert = insertClusivityBuilder == null ? properties : primaryKey.Properties.Concat(insertClusivityBuilder.Build(nonPrimaryKeyProperties)).ToArray();
 
-            (string targetCommand, IReadOnlyCollection<System.Data.SqlClient.SqlParameter> targetCommandParameters) = target.ToSqlCommand();
-
             var parameters = new List<object>(source.Count * properties.Length);
-            parameters.AddRange(targetCommandParameters);
 
             bool isSqlite = dbContext.Database.IsSqlite();
             if (isSqlite)
             {
                 stringBuilder.AddSqliteSyncCommand(
+                    dbContext: dbContext,
                     entityType: entityType,
+                    target: target,
+                    targetResolver: targetResolver,
                     source: source,
                     ignoreUpdates: ignoreUpdates,
                     ignoreDeletions: ignoreDeletions,
@@ -94,14 +241,15 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                     properties: properties,
                     propertiesToUpdate: propertiesToUpdate,
                     propertiesToInsert: propertiesToInsert,
-                    parameters: parameters,
-                    targetCommand: targetCommand);
+                    parameters: parameters);
             }
             else
             {
                 await stringBuilder.AddSqlServerSyncCommand(
                     dbContext: dbContext,
                     entityType: entityType,
+                    target: target,
+                    targetResolver: targetResolver,
                     source: source,
                     ignoreUpdates: ignoreUpdates,
                     ignoreDeletions: ignoreDeletions,
@@ -111,7 +259,6 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                     propertiesToUpdate: propertiesToUpdate,
                     propertiesToInsert: propertiesToInsert,
                     parameters: parameters,
-                    targetCommand: targetCommand,
                     cancellationToken);
             }
 
@@ -186,7 +333,10 @@ namespace EntityFrameworkCore.Manipulation.Extensions
 
         private static void AddSqliteSyncCommand<TEntity>(
             this StringBuilder stringBuilder,
+            DbContext dbContext,
             IEntityType entityType,
+            IQueryable<TEntity> target,
+            Func<(IQueryable<TEntity> source, IQueryable<TEntity> target), IQueryable<TEntity>> targetResolver,
             IReadOnlyCollection<TEntity> source,
             bool ignoreUpdates,
             bool ignoreDeletions,
@@ -195,10 +345,27 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             IProperty[] nonPrimaryKeyProperties,
             IProperty[] propertiesToUpdate,
             IProperty[] propertiesToInsert,
-            List<object> parameters,
-            string targetCommand)
+            List<object> parameters)
             where TEntity : class, new()
         {
+            string targetCommand = null;
+            IReadOnlyCollection<System.Data.SqlClient.SqlParameter> targetCommandParameters;
+
+            // If we got a resolver, we'll have to resolve the target.
+            if (targetResolver != null)
+            {
+                IQueryable<TEntity> sourceAsQueryable = dbContext.Set<TEntity>().FromSqlRaw("SELECT * FROM source");
+
+                target = targetResolver((sourceAsQueryable, dbContext.Set<TEntity>()));
+                (targetCommand, targetCommandParameters) = target.ToSqlCommand(filterCollapsedP0Param: true);
+            }
+            else
+            {
+                (targetCommand, targetCommandParameters) = target.ToSqlCommand();
+            }
+
+            parameters.AddRange(targetCommandParameters);
+
             string tableName = entityType.GetTableName();
             string SourceAliaser(string columnName) => $"source_{columnName}";
             string TargetAliaser(string columnName) => $"target_{columnName}";
@@ -212,12 +379,12 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                          .AppendLine("target AS ( ")
                             .Append(targetCommand)
                             .AppendLine(") ")
-                         .Append("SELECT (CASE WHEN (")
-                            .AppendJoin(" AND ", primaryKey.Properties.Select(property => FormattableString.Invariant($"target.{property.Name} IS NULL")))
+                         .AppendLine("SELECT (CASE WHEN (")
+                            .AppendJoin(" OR ", primaryKey.Properties.Select(property => FormattableString.Invariant($"target.{property.Name} IS NULL")))
                             .Append(") THEN 'INSERT' ELSE 'UPDATE' END) AS _$action, ")
                             .AppendColumnNames(properties, false, "source", SourceAliaser).Append(", ")
                             .AppendColumnNames(properties, false, "target", TargetAliaser)
-                            .Append("FROM source LEFT OUTER JOIN target ON ").AppendJoinCondition(primaryKey);
+                            .AppendLine("FROM source LEFT OUTER JOIN target ON ").AppendJoinCondition(primaryKey);
 
             // We ignore updates by not taking any matches in target (leaving us with only inserts, but crutially the target.* columns)
             if (ignoreUpdates)
@@ -234,7 +401,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                         .AppendColumnNames(properties, false, "source", SourceAliaser).Append(", ")
                         .AppendColumnNames(properties, false, "target", TargetAliaser)
                         .Append("FROM target LEFT OUTER JOIN source ON ").AppendJoinCondition(primaryKey)
-                        .Append("WHERE ").AppendJoin(" AND ", primaryKey.Properties.Select(property => FormattableString.Invariant($"source.{property.Name} IS NULL"))).AppendLine(";")
+                        .Append("WHERE ").AppendJoin(" OR ", primaryKey.Properties.Select(property => FormattableString.Invariant($"source.{property.Name} IS NULL"))).AppendLine(";")
                     .Append("DELETE FROM ").Append(tableName).Append(" WHERE EXISTS (SELECT 1 FROM EntityFrameworkManipulationSync WHERE _$action='DELETE' AND ")
                         .AppendJoin(" AND ", primaryKey.Properties.Select(property => FormattableString.Invariant($"{property.Name}={TargetAliaser(property.Name)}"))).AppendLine(");");
             }
@@ -269,6 +436,8 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             this StringBuilder stringBuilder,
             DbContext dbContext,
             IEntityType entityType,
+            IQueryable<TEntity> target,
+            Func<(IQueryable<TEntity> source, IQueryable<TEntity> target), IQueryable<TEntity>> targetResolver,
             IReadOnlyCollection<TEntity> source,
             bool ignoreUpdates,
             bool ignoreDeletions,
@@ -278,24 +447,52 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             IProperty[] propertiesToUpdate,
             IProperty[] propertiesToInsert,
             List<object> parameters,
-            string targetCommand,
             CancellationToken cancellationToken)
             where TEntity : class, new()
         {
             ManipulationExtensionsConfiguration configuration = dbContext.GetConfiguration();
 
+            string userDefinedTableTypeName = null;
+            string tableValuedParameter = null;
+
+            // There are three cases where we use a TVP as source:
+            // 1. when we exceed the param thresholds set in configuration
+            // 2. when we have a target resolver, and
+            // 3. when we do a simple-statement sync (i.e. not using MERGE)
+            if (configuration.SqlServerConfiguration.ShouldUseTableValuedParameters(properties, source)
+                || targetResolver != null
+                || !configuration.SqlServerConfiguration.ShouldUseMerge<TEntity>())
+            {
+                userDefinedTableTypeName = await dbContext.Database.CreateUserDefinedTableTypeIfNotExistsAsync(entityType, configuration.SqlServerConfiguration, cancellationToken);
+                tableValuedParameter = SqlCommandBuilderExtensions.CreateTableValuedParameter(userDefinedTableTypeName, properties, source, parameters);
+            }
+
+            string targetCommand = null;
+            IReadOnlyCollection<System.Data.SqlClient.SqlParameter> targetCommandParameters;
+
+            // If we got a resolver, we'll have to resolve the target.
+            if (targetResolver != null)
+            {
+                IQueryable<TEntity> sourceAsQueryable = dbContext.Set<TEntity>().FromSqlRaw(new StringBuilder().Append("SELECT * FROM ").Append(tableValuedParameter).ToString());
+
+                target = targetResolver((sourceAsQueryable, dbContext.Set<TEntity>()));
+                (targetCommand, targetCommandParameters) = target.ToSqlCommand(filterCollapsedP0Param: true);
+            }
+            else
+            {
+                (targetCommand, targetCommandParameters) = target.ToSqlCommand();
+            }
+
+            parameters.AddRange(targetCommandParameters);
+
             if (configuration.SqlServerConfiguration.ShouldUseMerge<TEntity>())
             {
                 bool outputInto = configuration.SqlServerConfiguration.DoesEntityHaveTriggers<TEntity>();
-                string userDefinedTableTypeName = null;
-                if (configuration.SqlServerConfiguration.ShouldUseTableValuedParameters(properties, source))
-                {
-                    userDefinedTableTypeName = await dbContext.Database.CreateUserDefinedTableTypeIfNotExistsAsync(entityType, configuration.SqlServerConfiguration, cancellationToken);
-                }
 
                 string outputType = null;
                 if (outputInto)
                 {
+                    // The output type is the same as userDefinedTableTypeName, but with an aditional field for Action
                     outputType = await dbContext.Database.CreateUserDefinedTableTypeIfNotExistsAsync(entityType, configuration.SqlServerConfiguration, cancellationToken, includeActionColumn: true);
                     stringBuilder.AppendOutputDeclaration(outputType);
                 }
@@ -306,9 +503,9 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                     .AppendLine("MERGE INTO TargetData AS target ")
                     .Append("USING ");
 
-                if (configuration.SqlServerConfiguration.ShouldUseTableValuedParameters(properties, source))
+                if (tableValuedParameter != null)
                 {
-                    stringBuilder.AppendTableValuedParameter(userDefinedTableTypeName, properties, source, parameters);
+                    stringBuilder.Append(tableValuedParameter);
                 }
                 else
                 {
@@ -343,10 +540,6 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             }
             else
             {
-                string userDefinedTableTypeName = null;
-                userDefinedTableTypeName = await dbContext.Database.CreateUserDefinedTableTypeIfNotExistsAsync(entityType, configuration.SqlServerConfiguration, cancellationToken);
-                string tvpParameter = SqlCommandBuilderExtensions.CreateTableValuedParameter(userDefinedTableTypeName, properties, source, parameters);
-
                 string tableName = entityType.GetSchemaQualifiedTableName();
                 stringBuilder
                     .AppendLine("SET NOCOUNT ON;")
@@ -362,7 +555,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                             .Append(targetCommand).AppendLine(")")
                         .AppendLine("DELETE FROM target")
                         .Append("OUTPUT ").AppendColumnNames(properties, wrapInParanthesis: false, "deleted").Append(" INTO ").AppendLine("@DeleteResult")
-                        .Append("WHERE NOT EXISTS (SELECT 1 FROM ").Append(tvpParameter).Append(" source WHERE ").AppendJoinCondition(primaryKey).AppendLine(");");
+                        .Append("WHERE NOT EXISTS (SELECT 1 FROM ").Append(tableValuedParameter).Append(" source WHERE ").AppendJoinCondition(primaryKey).AppendLine(");");
                 }
 
                 // UPDATE
@@ -373,7 +566,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                         .Append("UPDATE ").Append(tableName).AppendLine(" SET")
                             .AppendJoin(",", propertiesToUpdate.Select(property => FormattableString.Invariant($"{property.Name}=source.{property.Name}"))).AppendLine()
                         .Append("OUTPUT ").AppendColumnNames(properties, wrapInParanthesis: false, "deleted").Append(" INTO ").AppendLine("@UpdateResult")
-                        .Append("FROM ").Append(tableName).Append(" AS target INNER JOIN ").Append(tvpParameter).Append(" source ON ").AppendJoinCondition(primaryKey).AppendLine(";");
+                        .Append("FROM ").Append(tableName).Append(" AS target INNER JOIN ").Append(tableValuedParameter).Append(" source ON ").AppendJoinCondition(primaryKey).AppendLine(";");
                 }
 
                 // INSERT if not exists in taget table
@@ -382,7 +575,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                     .Append("INSERT INTO ").Append(tableName).AppendColumnNames(propertiesToInsert, wrapInParanthesis: true).AppendLine()
                     .Append("OUTPUT ").AppendColumnNames(properties, wrapInParanthesis: false, "inserted").Append(" INTO ").AppendLine("@InsertResult")
                     .Append("SELECT ").AppendJoin(",", propertiesToInsert.Select(m => m.GetColumnName())).AppendLine()
-                    .Append("FROM ").Append(tvpParameter).AppendLine(" source")
+                    .Append("FROM ").Append(tableValuedParameter).AppendLine(" source")
                     .Append("WHERE NOT EXISTS (SELECT 1 FROM ")
                         .Append(tableToCheckForExistence).Append(" target WHERE ")
                         .AppendJoinCondition(primaryKey).AppendLine(");");


### PR DESCRIPTION
Consumers can now create the `target` for a sync through a resolver, and base the target on the `source`. For example, ihe below code scopes the target to only delete entities which match on the `MyColumn` property.

```C#
dbContext.SyncAsync(
    targetResolver: x => x.target.Where(
        targetEntry => x.source.Any(sourceEntry => targetEntry.MyColumn == sourceEntry.MyColumn)),
    source);
```