### PR TITLE
Fixes parameter passthrough in target resolver

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/IQueryableExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/IQueryableExtensions.cs
@@ -1,9 +1,10 @@
-﻿namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
+namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
 {
     using Microsoft.EntityFrameworkCore.Query;
     using Microsoft.EntityFrameworkCore.Query.Internal;
     using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
     using Microsoft.EntityFrameworkCore.Storage;
+    using Microsoft.EntityFrameworkCore.Storage.Internal;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -14,7 +15,7 @@
 
     internal static class IQueryableExtensions
     {
-        public static (string CommantText, IReadOnlyCollection<SqlParameter> Parameters) ToSqlCommand<TEntity>(this IQueryable<TEntity> query, bool filterCollapsedP0Param = false)
+        public static (string CommantText, IReadOnlyCollection<SqlParameter> Parameters) ToSqlCommand<TEntity>(this IQueryable<TEntity> query, bool filterCompositeRelationParameter = false)
             where TEntity : class
         {
             IEnumerator<TEntity> enumerator = query.Provider.Execute<IEnumerable<TEntity>>(query.Expression).GetEnumerator();
@@ -41,7 +42,7 @@
             }
 
             SqlParameter[] sqlParams = command.Parameters
-                .Where(param => !filterCollapsedP0Param || param.InvariantName == "@__p_0")
+                .Where(param => !filterCompositeRelationParameter || !(param is CompositeRelationalParameter))
                 .Select(param => new SqlParameter($"@{param.InvariantName}", parameterValues[param.InvariantName]))
                 .ToArray();
 

--- a/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
@@ -357,7 +357,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                 IQueryable<TEntity> sourceAsQueryable = dbContext.Set<TEntity>().FromSqlRaw("SELECT * FROM source");
 
                 target = targetResolver((sourceAsQueryable, dbContext.Set<TEntity>()));
-                (targetCommand, targetCommandParameters) = target.ToSqlCommand(filterCollapsedP0Param: true);
+                (targetCommand, targetCommandParameters) = target.ToSqlCommand(filterCompositeRelationParameter: true);
             }
             else
             {
@@ -476,7 +476,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
                 IQueryable<TEntity> sourceAsQueryable = dbContext.Set<TEntity>().FromSqlRaw(new StringBuilder().Append("SELECT * FROM ").Append(tableValuedParameter).ToString());
 
                 target = targetResolver((sourceAsQueryable, dbContext.Set<TEntity>()));
-                (targetCommand, targetCommandParameters) = target.ToSqlCommand(filterCollapsedP0Param: true);
+                (targetCommand, targetCommandParameters) = target.ToSqlCommand(filterCompositeRelationParameter: true);
             }
             else
             {

--- a/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
@@ -101,7 +101,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             {
                 string incomingInlineTableCommand = new StringBuilder().AppendSelectFromInlineTable(properties, source, parameters, "x", sqliteSyntax: true).ToString();
                 IQueryable<TEntity> incoming = CreateIncomingQueryable(dbContext, incomingInlineTableCommand, condition, parameters);
-                (string sourceCommand, IReadOnlyCollection<SqlParameter> sourceCommandParameters) = incoming.ToSqlCommand(filterCollapsedP0Param: true);
+                (string sourceCommand, IReadOnlyCollection<SqlParameter> sourceCommandParameters) = incoming.ToSqlCommand(filterCompositeRelationParameter: true);
                 parameters.AddRange(sourceCommandParameters);
 
                 const string TempDeleteTableName = "EntityFrameworkManipulationUpdate";
@@ -146,7 +146,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
 
                 IQueryable<TEntity> incoming = CreateIncomingQueryable(dbContext, incomingInlineTableCommand, condition, parameters);
 
-                (string sourceCommand, IReadOnlyCollection<SqlParameter> sourceCommandParameters) = incoming.ToSqlCommand(filterCollapsedP0Param: true);
+                (string sourceCommand, IReadOnlyCollection<SqlParameter> sourceCommandParameters) = incoming.ToSqlCommand(filterCompositeRelationParameter: true);
                 parameters.AddRange(sourceCommandParameters);
 
                 // Here's where we have to cheat a bit to get an efficient query. If we were to place the sourceCommand in a CTE,


### PR DESCRIPTION
This fixes an issue where parameters applied a the `targetResolver` for a sync are not properly passed through to the SQL command, resulting in missing variables.