### PR TITLE
Migrate from System.Data.SqlClient to Microsoft.Data.SqlClient

### DIFF
--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/DeleteTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/DeleteTests.cs
@@ -8,7 +8,7 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Threading.Tasks;
 

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.csproj
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/ContextFactory.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/Helpers/ContextFactory.cs
@@ -5,7 +5,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
     using Microsoft.EntityFrameworkCore;
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Threading.Tasks;
 
     public enum DbProvider
@@ -41,6 +41,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.IntegrationTests.Helpers
                 {
                     DataSource = string.IsNullOrWhiteSpace(sqlServer) ? @"localhost\SQLEXPRESS" : sqlServer,
                     InitialCatalog = string.IsNullOrWhiteSpace(sqldb) ? @"entityframeworkcore-manipulation-extensions-integration-testing" : sqldb,
+                    TrustServerCertificate = true,
                 };
 
                 if (string.IsNullOrWhiteSpace(sqlUser) || string.IsNullOrWhiteSpace(sqlUser))

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/InsertIfNotExistTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/InsertIfNotExistTests.cs
@@ -7,7 +7,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
     using Microsoft.EntityFrameworkCore;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Threading.Tasks;
 

--- a/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions.IntegrationTests/SyncTests.cs
@@ -8,7 +8,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.UnitTests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Threading.Tasks;
 

--- a/EntityFrameworkCore.Manipulation.Extensions/DeleteExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/DeleteExtensions.cs
@@ -6,7 +6,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
     using Microsoft.EntityFrameworkCore.Metadata;
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Text;
     using System.Threading;

--- a/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
+++ b/EntityFrameworkCore.Manipulation.Extensions/EntityFrameworkCore.Manipulation.Extensions.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/DatabaseFacadeExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/DatabaseFacadeExtensions.cs
@@ -10,7 +10,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/IQueryableExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/IQueryableExtensions.cs
@@ -9,7 +9,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
     using System.Collections;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Reflection;
 

--- a/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/Internal/Extensions/SqlCommandBuilderExtensions.cs
@@ -6,7 +6,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions.Internal.Extensions
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Data;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Data.SqlTypes;
     using System.Linq;
     using System.Text;

--- a/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/SyncExtensions.cs
@@ -349,7 +349,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             where TEntity : class, new()
         {
             string targetCommand = null;
-            IReadOnlyCollection<System.Data.SqlClient.SqlParameter> targetCommandParameters;
+            IReadOnlyCollection<Microsoft.Data.SqlClient.SqlParameter> targetCommandParameters;
 
             // If we got a resolver, we'll have to resolve the target.
             if (targetResolver != null)
@@ -468,7 +468,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
             }
 
             string targetCommand = null;
-            IReadOnlyCollection<System.Data.SqlClient.SqlParameter> targetCommandParameters;
+            IReadOnlyCollection<Microsoft.Data.SqlClient.SqlParameter> targetCommandParameters;
 
             // If we got a resolver, we'll have to resolve the target.
             if (targetResolver != null)

--- a/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
+++ b/EntityFrameworkCore.Manipulation.Extensions/UpdateExtensions.cs
@@ -2,7 +2,7 @@ namespace EntityFrameworkCore.Manipulation.Extensions
 {
     using System;
     using System.Collections.Generic;
-    using System.Data.SqlClient;
+    using Microsoft.Data.SqlClient;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Text;


### PR DESCRIPTION
In order to support newer authentication methods such as Azure Managed Identities we're looking to migrate to the new SqlClient library. Unfortunately there's no direct compatibility here and changes to manipulations lib are necessary.

In this PR is the simplest change of migrating from one package over to the other.

**Is it possible to support both?**
For the most part there are 2 points of incompatibility I saw before I started making changes:

- connection string format change where the new format includes spaces in certain properties (e.g. "Application Intent" and not "ApplicationIntent") - this causes an exception where `System.Data.SqlClient.SqlConnectionBuilder` was used to retrieve metadata for cache key when adding a new Type for TableValuedParameter. It can be remedied by modifying the connection string before passing it to `SqlConnection` and removing those spaces for a select few fields (see [changed fields](https://github.com/dotnet/SqlClient/pull/534)).
- type incompatibility between `SqlParameter` from the packages - if you want to support both packages at the same time you need to be able to choose which `SqlParameter` to instantiate depending on the connection type.
I was able to get a decent fix in `ToSqlCommand()` extension method (below) but in `SqlCommandBuilderExtensions.CreateTableValuedParameter` we don't get it as easily.

```csharp

+            bool useSystemData = queryContext.Connection.DbConnection is System.Data.SqlClient.SqlConnection;
+
-            SqlParameter[] sqlParams = command.Parameters
+            object[] sqlParams = command.Parameters
                 .Where(param => !filterCompositeRelationParameter || !(param is CompositeRelationalParameter))
-                .Select(param => new SqlParameter($"@{param.InvariantName}", parameterValues[param.InvariantName]))
+                .Select(param => useSystemData
+                    ? (object)new System.Data.SqlClient.SqlParameter($"@{param.InvariantName}", parameterValues[param.InvariantName])
+                    : (object)new Microsoft.Data.SqlClient.SqlParameter($"@{param.InvariantName}", parameterValues[param.InvariantName]))
                 .ToArray();
```